### PR TITLE
Rename ChatGTP to ChatGPT

### DIFF
--- a/metadata/en-US/short_description.txt
+++ b/metadata/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Recipe manager and cooking assistant app with ChatGTP and Next Cloud integration
+Recipe manager and cooking assistant app with ChatGPT and Next Cloud integration

--- a/src-tauri/src/ai/chatgpt.rs
+++ b/src-tauri/src/ai/chatgpt.rs
@@ -6,19 +6,19 @@ use crate::ai::AIClient;
 
 use super::AIError;
 
-pub struct ChatGTPClient {
+pub struct ChatGPTClient {
     pub token: String,
     pub prompt: String,
 }
 
-impl ChatGTPClient {
-    pub fn new(token: String, prompt: String) -> ChatGTPClient {
-        ChatGTPClient { token, prompt }
+impl ChatGPTClient {
+    pub fn new(token: String, prompt: String) -> ChatGPTClient {
+        ChatGPTClient { token, prompt }
     }
 }
 
 #[async_trait]
-impl AIClient for ChatGTPClient {
+impl AIClient for ChatGPTClient {
     async fn parse_recipe(&self, recipe: String) -> Result<String, AIError> {
         let client = reqwest::Client::new();
 

--- a/src-tauri/src/commands/init_commands.rs
+++ b/src-tauri/src/commands/init_commands.rs
@@ -7,7 +7,7 @@ use recipes_common::{Config, RecipesSource, LLM};
 use tauri::async_runtime::Mutex;
 
 use crate::{
-    ai::{AIClient, ChatGTPClient, ClaudeClient, FreeClient, PerplexityClient},
+    ai::{AIClient, ChatGPTClient, ClaudeClient, FreeClient, PerplexityClient},
     commands::error::CommandError,
     recipes::{local::LocalClient, ncclient::NCClient, RecipesProvider},
 };
@@ -44,7 +44,7 @@ pub async fn initialize(
         let ai2: Box<dyn AIClient> = match config.llm {
             LLM::Free => Box::new(FreeClient::new(config.ai_prompt)),
             LLM::Claude => Box::new(ClaudeClient::new(config.ai_token, config.ai_prompt)),
-            LLM::GPT => Box::new(ChatGTPClient::new(config.ai_token, config.ai_prompt)),
+            LLM::GPT => Box::new(ChatGPTClient::new(config.ai_token, config.ai_prompt)),
             LLM::Perplexity => Box::new(PerplexityClient::new(config.ai_token, config.ai_prompt)),
         };
         *ai = Some(ai2);


### PR DESCRIPTION
Changes generated with:

```bash
grep -rlZ ChatGTP | xargs -0 sed -i 's/ChatGTP/ChatGPT/g'
```

Verified exhaustiveness thanks to:

```bash
grep -ri ChatGTP
```